### PR TITLE
Allow not depending on ocaml_instrinsics_kernel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 
+## Development Version
+- compatibility with ocaml 4.14
+
 ## 0.0.3.1
 - use ocaml_intrinsics_kernel
 

--- a/fast_bitvector.opam
+++ b/fast_bitvector.opam
@@ -8,16 +8,6 @@ license: "MPL-2.0"
 tags: ["bitvector" "bitset"]
 homepage: "https://github.com/engineeredabstraction/fast_bitvector"
 bug-reports: "https://github.com/engineeredabstraction/fast_bitvector/issues"
-depends: [
-  "dune" {>= "3.18"}
-  "ocaml" {>= "5.1.0"}
-  "ocaml_intrinsics_kernel"
-  "ppx_sexp_conv"
-  "ppx_sexp_value"
-  "expect_test_helpers_core" {with-test}
-  "ppx_jane" {with-test}
-  "odoc" {with-doc}
-]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -34,3 +24,12 @@ build: [
 ]
 dev-repo: "git+https://github.com/engineeredabstraction/fast_bitvector.git"
 x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.18"}
+  (("ocaml" {>= "4.14.0" & <"5.1.0"}) | ("ocaml" {>= "5.1.0"} & "ocaml_intrinsics_kernel"))
+  "ppx_sexp_conv"
+  "ppx_sexp_value"
+  "expect_test_helpers_core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]

--- a/fast_bitvector.opam.template
+++ b/fast_bitvector.opam.template
@@ -1,0 +1,9 @@
+depends: [
+  "dune" {>= "3.18"}
+  (("ocaml" {>= "4.14.0" & <"5.1.0"}) | ("ocaml" {>= "5.1.0"} & "ocaml_intrinsics_kernel"))
+  "ppx_sexp_conv"
+  "ppx_sexp_value"
+  "expect_test_helpers_core" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,10 @@
 (library
   (name fast_bitvector)
   (public_name fast_bitvector)
-  (libraries ocaml_intrinsics_kernel)
+  (libraries 
+    (select popcount64.ml from
+            (!ocaml_intrinsics_kernel -> popcount64.caml.ml)
+            (ocaml_intrinsics_kernel -> popcount64.intrinsic.ml)
+            ))
   (preprocess (pps ppx_sexp_conv ppx_sexp_value))
   )

--- a/src/dune
+++ b/src/dune
@@ -6,5 +6,6 @@
             (!ocaml_intrinsics_kernel -> popcount64.caml.ml)
             (ocaml_intrinsics_kernel -> popcount64.intrinsic.ml)
             ))
+  (modules fast_bitvector popcount64)
   (preprocess (pps ppx_sexp_conv ppx_sexp_value))
   )

--- a/src/dune
+++ b/src/dune
@@ -6,6 +6,5 @@
             (!ocaml_intrinsics_kernel -> popcount64.caml.ml)
             (ocaml_intrinsics_kernel -> popcount64.intrinsic.ml)
             ))
-  (modules fast_bitvector popcount64)
   (preprocess (pps ppx_sexp_conv ppx_sexp_value))
   )

--- a/src/fast_bitvector.ml
+++ b/src/fast_bitvector.ml
@@ -73,7 +73,7 @@ let [@inline always] foldop1 ~init ~f ~final a =
 let popcount t =
   foldop1 t 
     ~init:0
-    ~f:(fun acc v -> acc + (Ocaml_intrinsics_kernel.Int64.count_set_bits v))
+    ~f:(fun acc v -> acc + (Popcount64.count_set_bits v))
     ~final:(fun ~mask a -> Int64.logand mask a)
 
 let is_empty t =

--- a/src/popcount64.caml.ml
+++ b/src/popcount64.caml.ml
@@ -1,0 +1,8 @@
+
+let count_set_bits (i : int64) : int =
+  let open Int64 in
+  let i = sub i (logand (shift_right_logical i 1) 0x5555555555555555L) in
+  let i = add (logand i 0x3333333333333333L) (logand (shift_right_logical i 2) 0x3333333333333333L) in
+  let i = logand (add i (shift_right_logical i 4)) 0x0F0F0F0F0F0F0F0FL in
+  to_int (shift_right_logical (mul i 0x0101010101010101L) 56)
+

--- a/src/popcount64.intrinsic.ml
+++ b/src/popcount64.intrinsic.ml
@@ -1,0 +1,2 @@
+
+let count_set_bits = Ocaml_intrinsics_kernel.Int64.count_set_bits

--- a/test/test_fast_bitvector.ml
+++ b/test/test_fast_bitvector.ml
@@ -67,3 +67,23 @@ let%expect_test "Basic" =
     |}];
 
   ()
+
+let%expect_test "Popcount" =
+  let a = Fast_bitvector.create ~length:100 in
+  let pop = Fast_bitvector.popcount a in
+  print_s [%message "" (a : Fast_bitvector.t) (pop : int)];
+  [%expect {|
+    ((a (
+       LE
+       0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000))
+     (pop 0))
+    |}];
+  Fast_bitvector.set_all a;
+  let pop = Fast_bitvector.popcount a in
+  print_s [%message "" (a : Fast_bitvector.t) (pop : int)];
+  [%expect {|
+    ((a (
+       LE
+       1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111))
+     (pop 100))
+    |}]


### PR DESCRIPTION
So that older ocaml versions can be used.
Haven't tested yet.

@mbarbin, maybe something like this?